### PR TITLE
[Windows x64] Incorrect argument values being passed to callbacks

### DIFF
--- a/test/AMBuilder
+++ b/test/AMBuilder
@@ -28,6 +28,7 @@ for compiler in TestRunner.all_targets:
     'main.cpp',
     'test_functions.cpp',
     'test_members.cpp',
+    'test_regressions.cpp',
     'test_static_hook.cpp',
     'test_virtuals.cpp',
     'test_virtual_hook.cpp',

--- a/test/test_regressions.cpp
+++ b/test/test_regressions.cpp
@@ -1,0 +1,238 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <khook.hpp>
+#include <vector>
+#include "helpers.hpp"
+
+class IWideCallTarget
+{
+public:
+    virtual ~IWideCallTarget() = default;
+    virtual void DispatchWithManyArgs(
+        void *selector,
+        int targetId,
+        int groupId,
+        void *label,
+        float scale,
+        float spread,
+        int flags = 0,
+        int variant = 100,
+        int mode = 0,
+        void *primaryPoint = nullptr,
+        void *secondaryPoint = nullptr,
+        void *pointHistory = nullptr,
+        bool refreshState = true,
+        float scheduledTime = 0.0f,
+        int ownerToken = -1) = 0;
+};
+
+struct WideCallArgs
+{
+    void *target = nullptr;
+    void *selector = nullptr;
+    int targetId = 0;
+    int groupId = 0;
+    void *label = nullptr;
+    float scale = 0.0f;
+    float spread = 0.0f;
+    int flags = 0;
+    int variant = 0;
+    int mode = 0;
+    void *primaryPoint = nullptr;
+    void *secondaryPoint = nullptr;
+    void *pointHistory = nullptr;
+    bool refreshState = false;
+    float scheduledTime = 0.0f;
+    int ownerToken = 0;
+};
+
+struct WideCallArgsTestState
+{
+    WideCallArgs expectedArgs;
+    int preHookCalls = 0;
+    int originalCalls = 0;
+
+    void AssertEquals(const WideCallArgs &actualArgs)
+    {
+        EXPECT_EQ(actualArgs.target, expectedArgs.target);
+        EXPECT_EQ(actualArgs.selector, expectedArgs.selector);
+        EXPECT_EQ(actualArgs.targetId, expectedArgs.targetId);
+        EXPECT_EQ(actualArgs.groupId, expectedArgs.groupId);
+        EXPECT_EQ(actualArgs.label, expectedArgs.label);
+        EXPECT_EQ(actualArgs.scale, expectedArgs.scale);
+        EXPECT_EQ(actualArgs.spread, expectedArgs.spread);
+        EXPECT_EQ(actualArgs.flags, expectedArgs.flags);
+        EXPECT_EQ(actualArgs.variant, expectedArgs.variant);
+        EXPECT_EQ(actualArgs.mode, expectedArgs.mode);
+        EXPECT_EQ(actualArgs.primaryPoint, expectedArgs.primaryPoint);
+        EXPECT_EQ(actualArgs.secondaryPoint, expectedArgs.secondaryPoint);
+        EXPECT_EQ(actualArgs.pointHistory, expectedArgs.pointHistory);
+        EXPECT_EQ(actualArgs.refreshState, expectedArgs.refreshState);
+        EXPECT_EQ(actualArgs.scheduledTime, expectedArgs.scheduledTime);
+        EXPECT_EQ(actualArgs.ownerToken, expectedArgs.ownerToken);
+    }
+};
+
+static WideCallArgsTestState *g_wideCallTestState = nullptr;
+
+class WideCallTarget : public IWideCallTarget
+{
+public:
+    void DispatchWithManyArgs(
+        void *selector,
+        int targetId,
+        int groupId,
+        void *label,
+        float scale,
+        float spread,
+        int flags,
+        int variant,
+        int mode,
+        void *primaryPoint,
+        void *secondaryPoint,
+        void *pointHistory,
+        bool refreshState,
+        float scheduledTime,
+        int ownerToken) override
+    {
+        SCOPED_TRACE("original method");
+
+        ++g_wideCallTestState->originalCalls;
+        g_wideCallTestState->AssertEquals({
+            this,
+            selector,
+            targetId,
+            groupId,
+            label,
+            scale,
+            spread,
+            flags,
+            variant,
+            mode,
+            primaryPoint,
+            secondaryPoint,
+            pointHistory,
+            refreshState,
+            scheduledTime,
+            ownerToken,
+        });
+    }
+};
+
+using WideCallVirtualHook = KHook::Virtual<
+    IWideCallTarget,
+    void,
+    void *,
+    int,
+    int,
+    void *,
+    float,
+    float,
+    int,
+    int,
+    int,
+    void *,
+    void *,
+    void *,
+    bool,
+    float,
+    int>;
+
+static KHook::Return<void> WideCallPreValidateIgnore(
+    IWideCallTarget *hookedThis,
+    void *selector,
+    int targetId,
+    int groupId,
+    void *label,
+    float scale,
+    float spread,
+    int flags,
+    int variant,
+    int mode,
+    void *primaryPoint,
+    void *secondaryPoint,
+    void *pointHistory,
+    bool refreshState,
+    float scheduledTime,
+    int ownerToken)
+{
+    SCOPED_TRACE("pre-hook");
+
+    ++g_wideCallTestState->preHookCalls;
+    g_wideCallTestState->AssertEquals({
+        hookedThis,
+        selector,
+        targetId,
+        groupId,
+        label,
+        scale,
+        spread,
+        flags,
+        variant,
+        mode,
+        primaryPoint,
+        secondaryPoint,
+        pointHistory,
+        refreshState,
+        scheduledTime,
+        ownerToken,
+    });
+    return {KHook::Action::Ignore};
+}
+
+TEST(RegressionTests, WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook)
+{
+    WideCallTarget target;
+    IWideCallTarget *targetPtr = &target; // prevent compiler from de-virtualizing the call
+
+    int selector = 24;
+    float primaryPoint = 1.0f;
+    float secondaryPoint = 3.0f;
+    std::vector<float> pointHistory{8.0f, 13.0f, 21.0f};
+
+    WideCallArgsTestState state;
+    state.expectedArgs.target = targetPtr;
+    state.expectedArgs.selector = &selector;
+    state.expectedArgs.targetId = 17;
+    state.expectedArgs.groupId = 5;
+    state.expectedArgs.label = nullptr;
+    state.expectedArgs.scale = 0.42f;
+    state.expectedArgs.spread = 0.66f;
+    state.expectedArgs.flags = 19;
+    state.expectedArgs.variant = 123;
+    state.expectedArgs.mode = 7;
+    state.expectedArgs.primaryPoint = &primaryPoint;
+    state.expectedArgs.secondaryPoint = &secondaryPoint;
+    state.expectedArgs.pointHistory = &pointHistory;
+    state.expectedArgs.refreshState = false;
+    state.expectedArgs.scheduledTime = 3.5f;
+    state.expectedArgs.ownerToken = 1337;
+
+    g_wideCallTestState = &state;
+
+    WideCallVirtualHook hook(&IWideCallTarget::DispatchWithManyArgs, &WideCallPreValidateIgnore, nullptr);
+    hook.Add(targetPtr);
+
+    targetPtr->DispatchWithManyArgs(
+        state.expectedArgs.selector,
+        state.expectedArgs.targetId,
+        state.expectedArgs.groupId,
+        state.expectedArgs.label,
+        state.expectedArgs.scale,
+        state.expectedArgs.spread,
+        state.expectedArgs.flags,
+        state.expectedArgs.variant,
+        state.expectedArgs.mode,
+        state.expectedArgs.primaryPoint,
+        state.expectedArgs.secondaryPoint,
+        state.expectedArgs.pointHistory,
+        state.expectedArgs.refreshState,
+        state.expectedArgs.scheduledTime,
+        state.expectedArgs.ownerToken);
+
+    EXPECT_EQ(state.preHookCalls, 1) << "Pre-hook should run exactly once";
+    EXPECT_EQ(state.originalCalls, 1)
+        << "Original method should still run after Ignore";
+
+    g_wideCallTestState = nullptr;
+}


### PR DESCRIPTION
For functions that have more than 14 arguments, there seems to be some sort of edge case where arguments after a certain point don't get passed correctly when hooked, leading to incorrect argument values being passed to both pre-hook callbacks and the original function's logic. This problem seems to be only unique on Windows 64-bit, as it doesn't come up in testing with Windows 32-bit.

This bug was observed when attempting to hook onto [`IEngineSound::EmitSound`](https://github.com/ValveSoftware/source-sdk-2013/blob/3300848d8a25ef6403c91f82a4cd97d6daefbc06/src/public/engine/IEngineSound.h#L104) and either of its overloads. `speakerEntity` is supposed to hold entindexes, yet it was observed to contain bogus (sometimes negative) values.

I created a test that tests a function with a similar prototype in this PR, and the same bug occurs with `ownerToken`. Test shows the last two arguments being passed to the pre-hook and original functions with wrong values, which is similar to what was observed with the `EmitSound` hook.

<details>
<summary>Windows 64-bit logs</summary>

```
[0/52] Running tests...
[1/52] VirtualHookTests.SupersedeThenNoopHooksOnSameIndex (37 ms)
[2/52] MemberTests.PreAndPostCallbacks (36 ms)
[3/52] StaticHookTest.SupersedeVoidReturnValue (38 ms)
[4/52] FunctionTests.ContextSupersedePreCallback (34 ms)
[5/52] VirtualHookTests.SupersedeVoidReturnValue (38 ms)
[6/52] FunctionTests.ContextPostCallback (38 ms)
[7/52] RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook (39 ms)
Note: Google Test filter = RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from RegressionTests
[ RUN      ] RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook
D:\repo\alliedmodders\KHook\test\test_regressions.cpp(71): error: Expected equality of these values:
  actualArgs.scheduledTime
    Which is: 0.42
  expectedArgs.scheduledTime
    Which is: 3.5
Google Test trace:
D:\repo\alliedmodders\KHook\test\test_regressions.cpp(159): pre-hook

D:\repo\alliedmodders\KHook\test\test_regressions.cpp(72): error: Expected equality of these values:
  actualArgs.ownerToken
    Which is: 1161752248
  expectedArgs.ownerToken
    Which is: 1337
Google Test trace:
D:\repo\alliedmodders\KHook\test\test_regressions.cpp(159): pre-hook

D:\repo\alliedmodders\KHook\test\test_regressions.cpp(71): error: Expected equality of these values:
  actualArgs.scheduledTime
    Which is: 0.42
  expectedArgs.scheduledTime
    Which is: 3.5
Google Test trace:
D:\repo\alliedmodders\KHook\test\test_regressions.cpp(98): original method

D:\repo\alliedmodders\KHook\test\test_regressions.cpp(72): error: Expected equality of these values:
  actualArgs.ownerToken
    Which is: 1161752248
  expectedArgs.ownerToken
    Which is: 1337
Google Test trace:
D:\repo\alliedmodders\KHook\test\test_regressions.cpp(98): original method

[  FAILED  ] RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook (1 ms)
[----------] 1 test from RegressionTests (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook

 1 FAILED TEST
[7/52] RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook returned with exit code 1 (39 ms)
[8/52] VirtualTests.ContextPreCallback (38 ms)
[9/52] VirtualTests.PreCallback (53 ms)
[10/52] FunctionTests.MultipleContextsPreCallback (54 ms)
[11/52] StaticHookTest.SupersedeThenNoopHooksOnSameFunction (55 ms)
[12/52] VirtualHookTests.Noop (52 ms)
[13/52] FunctionTests.ContextPreAndPostCallbacks (50 ms)
[14/52] FunctionTests.ContextPreCallback (50 ms)
[15/52] VirtualHookTests.NoopVoid (52 ms)
[16/52] StaticHookTest.Noop (53 ms)
[17/52] VirtualHookTests.MultipleNoopVoidHooksOnSameIndex (53 ms)
[18/52] MemberTests.ContextPostCallback (54 ms)
[19/52] VirtualHookTests.SupersedeThenNoopVoidHooksOnSameIndex (53 ms)
[20/52] StaticHookTest.MultipleNoopVoidHooksOnSameFunction (53 ms)
[21/52] FunctionTests.NoopPreCallback (28 ms)
[22/52] MemberTests.ContextSupersedePreCallback (30 ms)
[23/52] MemberTests.MultipleContextsPreCallback (32 ms)
[24/52] FunctionTests.NoopPostCallback (30 ms)
[25/52] VirtualTests.InstanceOnly (30 ms)
[26/52] StaticHookTest.SupersedeReturnValue (30 ms)
[27/52] VirtualHookTests.OverrideReturnValuePre (8 ms)
[28/52] VirtualTests.PreAndPostCallbacks (27 ms)
[29/52] StaticHookTest.OverrideReturnValuePre (28 ms)
[30/52] VirtualHookTests.HookIsAllowedInsideSetObjectValue (33 ms)
[31/52] VirtualHookTests.OverrideReturnValuePost (30 ms)
[32/52] VirtualHookTests.SupersedeReturnValue (30 ms)
[33/52] VirtualTests.ContextPostCallback (34 ms)
[34/52] StaticHookTest.OverrideParameterWithRecall (29 ms)
[35/52] VirtualTests.ContextSupersedePreCallback (9 ms)
[36/52] VirtualTests.SupersedePreCallback (13 ms)
[37/52] VirtualHookTests.OverrideParameterWithRecall (10 ms)
[38/52] StaticHookTest.SupersedeThenNoopVoidHooksOnSameFunction (45 ms)
[39/52] MemberTests.ContextPreAndPostCallbacks (45 ms)
[40/52] MemberTests.PostCallback (29 ms)
[41/52] MemberTests.SupersedePreCallback (22 ms)
[42/52] MemberTests.PreCallback (44 ms)
[43/52] FunctionTests.SupersedePreCallback (29 ms)
[44/52] VirtualTests.PostCallback (29 ms)
[45/52] StaticHookTest.OverrideReturnValuePost (29 ms)
[46/52] VirtualTests.ContextPreAndPostCallbacks (45 ms)
[47/52] StaticHookTest.NoopVoid (29 ms)
[48/52] VirtualTests.MultipleContextsPreCallback (45 ms)
[49/52] MemberTests.ContextPreCallback (45 ms)
[50/52] FunctionTests.NoopPreAndPostCallbacks (45 ms)
[51/52] VirtualTests.ContextInstanceOnly (27 ms)
[52/52] StaticHookTest.HookIsAllowedInsideSetObjectValue (30 ms)
FAILED TESTS (1/52):
      39 ms: D:\repo\alliedmodders\KHook\build\package\x86_64\testrunner.exe RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook
```

</details>

On 32-bit, the test passes.

<details>
<summary>Windows 32-bit logs</summary>

```
[0/52] Running tests...
[1/52] MemberTests.ContextPostCallback (27 ms)
[2/52] RegressionTests.WideVirtualCallArgumentsRemainConsistentAfterNoopPreHook (26 ms)
[3/52] MemberTests.MultipleContextsPreCallback (41 ms)
[4/52] VirtualTests.MultipleContextsPreCallback (42 ms)
[5/52] FunctionTests.NoopPostCallback (38 ms)
[6/52] FunctionTests.ContextPostCallback (44 ms)
[7/52] VirtualTests.PreCallback (42 ms)
[8/52] VirtualTests.ContextPreAndPostCallbacks (44 ms)
[9/52] VirtualHookTests.NoopVoid (43 ms)
[10/52] StaticHookTest.NoopVoid (32 ms)
[11/52] VirtualHookTests.SupersedeThenNoopHooksOnSameIndex (59 ms)
[12/52] MemberTests.PreCallback (59 ms)
[13/52] VirtualHookTests.MultipleNoopVoidHooksOnSameIndex (59 ms)
[14/52] FunctionTests.MultipleContextsPreCallback (61 ms)
[15/52] FunctionTests.ContextPreCallback (58 ms)
[16/52] FunctionTests.ContextPreAndPostCallbacks (58 ms)
[17/52] StaticHookTest.SupersedeThenNoopHooksOnSameFunction (59 ms)
[18/52] VirtualHookTests.SupersedeThenNoopVoidHooksOnSameIndex (58 ms)
[19/52] VirtualTests.ContextPostCallback (56 ms)
[20/52] MemberTests.ContextSupersedePreCallback (15 ms)
[21/52] FunctionTests.NoopPreCallback (28 ms)
[22/52] StaticHookTest.HookIsAllowedInsideSetObjectValue (29 ms)
[23/52] StaticHookTest.MultipleNoopVoidHooksOnSameFunction (46 ms)
[24/52] FunctionTests.NoopPreAndPostCallbacks (30 ms)
[25/52] VirtualTests.InstanceOnly (32 ms)
[26/52] VirtualHookTests.Noop (32 ms)
[27/52] VirtualTests.PreAndPostCallbacks (32 ms)
[28/52] MemberTests.ContextPreAndPostCallbacks (76 ms)
[29/52] StaticHookTest.SupersedeThenNoopVoidHooksOnSameFunction (76 ms)
[30/52] VirtualHookTests.OverrideReturnValuePost (18 ms)
[31/52] VirtualTests.ContextSupersedePreCallback (15 ms)
[32/52] VirtualHookTests.SupersedeReturnValue (29 ms)
[33/52] StaticHookTest.OverrideParameterWithRecall (30 ms)
[34/52] VirtualTests.PostCallback (29 ms)
[35/52] StaticHookTest.SupersedeReturnValue (30 ms)
[36/52] StaticHookTest.OverrideReturnValuePre (29 ms)
[37/52] StaticHookTest.Noop (29 ms)
[38/52] FunctionTests.ContextSupersedePreCallback (29 ms)
[39/52] VirtualTests.ContextPreCallback (29 ms)
[40/52] VirtualTests.SupersedePreCallback (30 ms)
[41/52] MemberTests.PreAndPostCallbacks (26 ms)
[42/52] VirtualHookTests.OverrideReturnValuePre (28 ms)
[43/52] VirtualHookTests.OverrideParameterWithRecall (32 ms)
[44/52] MemberTests.ContextPreCallback (29 ms)
[45/52] StaticHookTest.SupersedeVoidReturnValue (32 ms)
[46/52] VirtualHookTests.SupersedeVoidReturnValue (34 ms)
[47/52] MemberTests.SupersedePreCallback (32 ms)
[48/52] VirtualTests.ContextInstanceOnly (34 ms)
[49/52] MemberTests.PostCallback (32 ms)
[50/52] FunctionTests.SupersedePreCallback (32 ms)
[51/52] StaticHookTest.OverrideReturnValuePost (32 ms)
[52/52] VirtualHookTests.HookIsAllowedInsideSetObjectValue (30 ms)
```

</details>