### PR TITLE
Widen stack allocation to pointer-size

### DIFF
--- a/include/khook.hpp
+++ b/include/khook.hpp
@@ -95,10 +95,10 @@ protected:
 #else
 		std::uint32_t return_size = 0;
 		if constexpr(!std::is_void_v<RETURN>) {
-			return_size = sizeof(RETURN);
+			return_size = std::max(sizeof(void*), sizeof(RETURN));
 		}
 
-		return return_size + (sizeof(ARGS) + ... + 0);
+		return return_size + (std::max(sizeof(void*), sizeof(ARGS)) + ... + 0);
 #endif
 	}
 protected:
@@ -614,7 +614,7 @@ protected:
 			(void*)Self::_KHook_Callback_POST, // postMFP
 			(void*)Self::_KHook_MakeReturn, // returnMFP,
 			(void*)Self::_KHook_MakeOriginalCall, // callOriginalMFP
-			_copy_stack_size<void*, ARGS...>(),
+			Self::template _copy_stack_size<void*, ARGS...>(),
 			true // For safety reasons we are adding hooks asynchronously. If performance is required, reimplement this class
 		);
 		if (_associated_hook_id != INVALID_HOOK) {
@@ -1252,7 +1252,7 @@ protected:
 			ExtractMFP(&Self::_KHook_Callback_POST), // postMFP
 			ExtractMFP(&Self::_KHook_MakeReturn), // returnMFP,
 			ExtractMFP(&Self::_KHook_MakeOriginalCall), // callOriginalMFP
-			_copy_stack_size<void*, ARGS...>(),
+			Self::template _copy_stack_size<void*, ARGS...>(),
 			true // For safety reasons we are adding hooks asynchronously. If performance is required, reimplement this class
 		);
 		if (_associated_hook_id != INVALID_HOOK) {
@@ -1916,7 +1916,7 @@ protected:
 			ExtractMFP(&Self::_KHook_Callback_POST), // postMFP
 			ExtractMFP(&Self::_KHook_MakeReturn), // returnMFP,
 			ExtractMFP(&Self::_KHook_MakeOriginalCall), // callOriginalMFP
-			_copy_stack_size<void*, ARGS...>(),
+			Self::template _copy_stack_size<void*, ARGS...>(),
 			true // For safety reasons we are adding hooks asynchronously. If performance is required, reimplement this class
 		);
 		if (id != INVALID_HOOK) {

--- a/test.py
+++ b/test.py
@@ -12,12 +12,12 @@ CONFIGURE_SCRIPT_PATH = os.path.join(SCRIPT_DIR, "configure.py")
 def configure(build_dir, target):
   if not os.path.isdir(build_dir):
     os.mkdir(build_dir)
-  result = subprocess.run([sys.executable, CONFIGURE_SCRIPT_PATH, "--targets", target, "--enable-tests"], cwd=build_dir, shell=True)
+  result = subprocess.run([sys.executable, CONFIGURE_SCRIPT_PATH, "--targets", target, "--enable-tests"], cwd=build_dir)
   if result.returncode != 0:
     sys.exit(result.returncode)
 
 def build(build_dir):
-  result = subprocess.run(["ambuild"], cwd=build_dir, shell=True)
+  result = subprocess.run(["ambuild"], cwd=build_dir)
   if result.returncode != 0:
     sys.exit(result.returncode)
 
@@ -34,7 +34,7 @@ def run_tests(build_dir, target):
     print(f"Test binary not found: {test_binary}")
     sys.exit(1)
   gtest_parallel = os.path.abspath(GTEST_PARALLEL_PATH)
-  result = subprocess.run([sys.executable, gtest_parallel, test_binary], shell=True)
+  result = subprocess.run([sys.executable, gtest_parallel, test_binary])
   sys.exit(result.returncode)
 
 def main():

--- a/test/AMBuilder
+++ b/test/AMBuilder
@@ -42,6 +42,9 @@ for compiler in TestRunner.all_targets:
     ]
 
   if compiler.target.platform == 'linux':
+    compiler.linkflags += [
+      '-pthread'
+    ]
     pass
   elif compiler.target.platform == 'mac':
     pass

--- a/test/test_regressions.cpp
+++ b/test/test_regressions.cpp
@@ -113,12 +113,10 @@ namespace {
 						true,
 						70023);
 				}
-				else {
-					static_assert(false, "expected arguments not set for test case");
-				}
+				throw std::runtime_error("expected arguments not set for test case");
 			}
 
-			static constexpr typename RETURN GetExpectedReturn() {
+			static constexpr RETURN GetExpectedReturn() {
 				if constexpr(std::is_void_v<RETURN>) {
 					return;
 				}
@@ -139,9 +137,7 @@ namespace {
 						reinterpret_cast<void*>((std::uintptr_t)0x1200056)
 					);
 				}
-				else {
-					static_assert(false, "expected return not set for test case");
-				}
+				throw std::runtime_error("expected return not set for test case");
 			}
 
 			TestCase() : _orig_calls(0), _hook_calls(0) {
@@ -221,11 +217,11 @@ namespace {
 		TYPED_TEST_SUITE(Regression_StackCopySizeTests, AllCases);
 
 		TYPED_TEST(Regression_StackCopySizeTests, Function) {
-			TypeParam::FunctionHook hook(&TypeParam::FunctionCall, _case, &TypeParam::Callback, nullptr);
+			typename TypeParam::FunctionHook hook(&TypeParam::FunctionCall, this->_case, &TypeParam::Callback, nullptr);
 
 			auto expected = TypeParam::GetExpectedArgs();
 			std::apply([&](auto&&... args) {
-				if constexpr(std::is_void_v<TypeParam::Return>) {
+				if constexpr(std::is_void_v<typename TypeParam::Return>) {
 					TypeParam::FunctionCall(std::forward<decltype(args)>(args)...);
 				}
 				else {
@@ -235,47 +231,47 @@ namespace {
 				}
 			}, expected);
 
-			EXPECT_EQ(_case->GetNumHookCalls(), 1) << "Pre-hook should run exactly once";
-			EXPECT_EQ(_case->GetNumOrigStaticCalls(), 1) << "Original method should still run after Ignore";
+			EXPECT_EQ(this->_case->GetNumHookCalls(), 1) << "Pre-hook should run exactly once";
+			EXPECT_EQ(this->_case->GetNumOrigStaticCalls(), 1) << "Original method should still run after Ignore";
 		}
 
 		TYPED_TEST(Regression_StackCopySizeTests, Member) {
-			TypeParam::MemberHook hook(&TypeParam::MemberCall, &TypeParam::Callback, nullptr);
+			typename TypeParam::MemberHook hook(&TypeParam::MemberCall, &TypeParam::Callback, nullptr);
 
 			auto expected = TypeParam::GetExpectedArgs();
 			std::apply([&](auto&&... args) {
-				if constexpr(std::is_void_v<TypeParam::Return>) {
-					_case->MemberCall(std::forward<decltype(args)>(args)...);
+				if constexpr(std::is_void_v<typename TypeParam::Return>) {
+					this->_case->MemberCall(std::forward<decltype(args)>(args)...);
 				}
 				else {
 					auto expected_ret = TypeParam::GetExpectedReturn();
-					auto actual_ret = _case->MemberCall(std::forward<decltype(args)>(args)...);
+					auto actual_ret = this->_case->MemberCall(std::forward<decltype(args)>(args)...);
 					EXPECT_EQ(expected_ret, actual_ret);
 				}
 			}, expected);
 
-			EXPECT_EQ(_case->GetNumHookCalls(), 1) << "Pre-hook should run exactly once";
-			EXPECT_EQ(_case->GetNumOrigCalls(), 1) << "Original method should still run after Ignore";
+			EXPECT_EQ(this->_case->GetNumHookCalls(), 1) << "Pre-hook should run exactly once";
+			EXPECT_EQ(this->_case->GetNumOrigCalls(), 1) << "Original method should still run after Ignore";
 		}
 
 		TYPED_TEST(Regression_StackCopySizeTests, Virtual) {
-			TypeParam::VirtualHook hook(&TypeParam::VirtualCall, &TypeParam::Callback, nullptr);
-			hook.Add(_case);
+			typename TypeParam::VirtualHook hook(&TypeParam::VirtualCall, &TypeParam::Callback, nullptr);
+			hook.Add(this->_case);
 
 			auto expected = TypeParam::GetExpectedArgs();
 			std::apply([&](auto&&... args) {
-				if constexpr(std::is_void_v<TypeParam::Return>) {
-					_case->VirtualCall(std::forward<decltype(args)>(args)...);
+				if constexpr(std::is_void_v<typename TypeParam::Return>) {
+					this->_case->VirtualCall(std::forward<decltype(args)>(args)...);
 				}
 				else {
 					auto expected_ret = TypeParam::GetExpectedReturn();
-					auto actual_ret = _case->VirtualCall(std::forward<decltype(args)>(args)...);
+					auto actual_ret = this->_case->VirtualCall(std::forward<decltype(args)>(args)...);
 					EXPECT_EQ(expected_ret, actual_ret);
 				}
 			}, expected);
 
-			EXPECT_EQ(_case->GetNumHookCalls(), 1) << "Pre-hook should run exactly once";
-			EXPECT_EQ(_case->GetNumOrigCalls(), 1) << "Original method should still run after Ignore";
+			EXPECT_EQ(this->_case->GetNumHookCalls(), 1) << "Pre-hook should run exactly once";
+			EXPECT_EQ(this->_case->GetNumOrigCalls(), 1) << "Original method should still run after Ignore";
 		}
 	}
 }


### PR DESCRIPTION
Adjusts the stack size calculation to ensure all sizes are of at least pointer-size before being summed. Also fixes Linux compilation warnings and errors introduced by #11.