### PR TITLE
Fixes found while integrating KHook with SourceMod

### DIFF
--- a/include/khook/asm.hpp
+++ b/include/khook/asm.hpp
@@ -317,9 +317,8 @@ namespace KHook
 		a waste of virtual address space (Windows’ VirtualAlloc has a granularity of 64K).
 
 
-		IMPORTANT: the memory that Alloc() returns is not a in a defined state!
-		It could be in read+exec OR read+write mode.
-		-> call SetRE() or SetRW() before using allocated memory!
+		Memory that Alloc() returns is mapped read+write+execute, so it can be
+		written to (code generation) and executed without any further protection changes.
 		*/
 		class CPageAlloc
 		{
@@ -346,7 +345,6 @@ namespace KHook
 				bool isolated;
 				std::size_t minAlignment;
 				AUList allocUnits;
-				bool isRE;
 
 				void CheckGap(std::size_t gap_begin, std::size_t gap_end, std::size_t reqsize,
 					std::size_t &smallestgap_pos, std::size_t &smallestgap_size, std::size_t &outAlignBytes)
@@ -431,21 +429,10 @@ namespace KHook
 
 				void DebugCleanMemory(unsigned char* start, size_t size)
 				{
-					bool wasRE = isRE;
-					if (isRE)
-					{
-						SetRW();
-					}
-
 					unsigned char* end = start + size;
 					for (unsigned char* p = start; p != end; ++p)
 					{
 						*p = 0xCC;
-					}
-
-					if (wasRE)
-					{
-						SetRE();
 					}
 				}
 
@@ -461,16 +448,6 @@ namespace KHook
 #else
 					munmap(startPtr, size);
 #endif
-				}
-
-				void SetRE()
-				{
-					isRE = true;
-				}
-
-				void SetRW()
-				{
-					isRE = false;
 				}
 			};
 
@@ -503,7 +480,6 @@ namespace KHook
 
 				if (newRegion.startPtr)
 				{
-					newRegion.SetRW();
 					m_Regions.push_back(newRegion);
 					return true;
 				}
@@ -582,30 +558,6 @@ namespace KHook
 				}
 			}
 
-			void SetRE(void *ptr)
-			{
-				for (ARList::iterator iter = m_Regions.begin(); iter != m_Regions.end(); ++iter)
-				{
-					if (iter->Contains(ptr))
-					{
-						iter->SetRE();
-						break;
-					}
-				}
-			}
-
-			void SetRW(void *ptr)
-			{
-				for (ARList::iterator iter = m_Regions.begin(); iter != m_Regions.end(); ++iter)
-				{
-					if (iter->Contains(ptr))
-					{
-						iter->SetRW();
-						break;
-					}
-				}
-			}
-
 			std::size_t GetPageSize()
 			{
 				return m_PageSize;
@@ -647,10 +599,6 @@ namespace KHook
 				m_AllocatedSize = 0;
 			}
 
-			void SetRE() {
-				Allocator.SetRE(reinterpret_cast<void*>(m_pData));
-			}
-
 			operator void *() {
 				return reinterpret_cast<void*>(GetData());
 			}
@@ -687,7 +635,6 @@ private:
 
 					unsigned char *newBuf;
 					newBuf = reinterpret_cast<unsigned char*>(Allocator.Alloc(m_AllocatedSize));
-					Allocator.SetRW(newBuf);
 					if (!newBuf) {
 						assertm(false, "bad_alloc: couldn't allocate new bytes of memory\n");
 						return;
@@ -695,8 +642,6 @@ private:
 					std::memset((void*)newBuf, 0xCC, m_AllocatedSize);			// :TODO: remove this !
 					std::memcpy((void*)newBuf, (const void*)m_pData, m_Size);
 					if (m_pData) {
-						Allocator.SetRE(reinterpret_cast<void*>(m_pData));
-						Allocator.SetRW(newBuf);
 						Allocator.Free(reinterpret_cast<void*>(m_pData));
 					}
 					m_pData = newBuf;

--- a/include/khook/asm.hpp
+++ b/include/khook/asm.hpp
@@ -465,13 +465,11 @@ namespace KHook
 
 				void SetRE()
 				{
-					Memory::SetAccess(startPtr, size, Memory::Flags::READ | Memory::Flags::EXECUTE);
 					isRE = true;
 				}
 
 				void SetRW()
 				{
-					Memory::SetAccess(startPtr, size, Memory::Flags::READ | Memory::Flags::WRITE);
 					isRE = false;
 				}
 			};
@@ -496,9 +494,11 @@ namespace KHook
 					newRegion.size += m_PageSize;
 
 #ifdef _WIN32
-				newRegion.startPtr = VirtualAlloc(nullptr, newRegion.size, MEM_COMMIT, PAGE_READWRITE);
+				newRegion.startPtr = VirtualAlloc(nullptr, newRegion.size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #else
-				newRegion.startPtr = mmap(0, newRegion.size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+				newRegion.startPtr = mmap(0, newRegion.size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, -1, 0);
+				if (newRegion.startPtr == MAP_FAILED)
+					newRegion.startPtr = nullptr;
 #endif
 
 				if (newRegion.startPtr)

--- a/src/detour.cpp
+++ b/src/detour.cpp
@@ -1781,7 +1781,10 @@ KHOOK_API void RemoveHook(
 				continue;
 			}
 
-			// Hook not yet been inserted, remove it right now
+			// Hook not yet been inserted, remove it right now.
+			// Capture the remove-callback details before erase frees the node.
+			auto remove_fn = it->second.hook_fn_remove;
+			auto ctx_ptr = it->second.hook_ptr;
 			g_insert_hooks.erase(it);
 
 			// Disassociate from the detour
@@ -1790,15 +1793,14 @@ KHOOK_API void RemoveHook(
 				g_associated_hooks.erase(id);
 			}
 
-			auto& hook = it->second;
-
 			// Invoke remove callback
-			if (hook.hook_fn_remove) {
-				auto fn = reinterpret_cast<void (*)(HookID_t)>(hook.hook_fn_remove);
-				PushPopCurrentHook(reinterpret_cast<void*>(hook.hook_ptr), true);
+			if (remove_fn) {
+				auto fn = reinterpret_cast<void (*)(HookID_t)>(remove_fn);
+				PushPopCurrentHook(reinterpret_cast<void*>(ctx_ptr), true);
 				fn(id);
-				PushPopCurrentHook(reinterpret_cast<void*>(hook.hook_ptr), false);
+				PushPopCurrentHook(reinterpret_cast<void*>(ctx_ptr), false);
 			}
+			break;
 		}
 	}
 

--- a/src/detour.cpp
+++ b/src/detour.cpp
@@ -1414,7 +1414,6 @@ DetourCapsule::DetourCapsule(std::uint32_t stack_size) :
 	//_jit.breakpoint();
 	_jit.retn();
 #endif
-	_jit.SetRE();
 	void* bridge = _jit;
 	_jit_func_ptr = reinterpret_cast<std::uintptr_t>(bridge);
 }

--- a/src/detour.cpp
+++ b/src/detour.cpp
@@ -1524,14 +1524,17 @@ void DetourCapsule::RemoveHook(HookID_t id) {
 		if (hook == _end_callbacks) {
 			_end_callbacks = _end_callbacks->prev;
 		}
-		
+
+		auto remove_fn = hook->hook_fn_remove;
+		auto ctx_ptr = hook->hook_ptr;
+
 		_callbacks.erase(it);
 
-		if (hook->hook_fn_remove) {
-			auto fn = reinterpret_cast<void (*)(HookID_t)>(hook->hook_fn_remove);
-			PushPopCurrentHook(reinterpret_cast<void*>(hook->hook_ptr), true);
+		if (remove_fn) {
+			auto fn = reinterpret_cast<void (*)(HookID_t)>(remove_fn);
+			PushPopCurrentHook(reinterpret_cast<void*>(ctx_ptr), true);
 			fn(id);
-			PushPopCurrentHook(reinterpret_cast<void*>(hook->hook_ptr), false);
+			PushPopCurrentHook(reinterpret_cast<void*>(ctx_ptr), false);
 		}
 	}
 }

--- a/src/ranges.cpp
+++ b/src/ranges.cpp
@@ -24,7 +24,7 @@ bool Add(std::unique_ptr<Range> range) {
 	g_ranges.begin(),
 	g_ranges.end(),
 	range->begin,
-	[](const std::unique_ptr<Range>& r, uint32_t value) {
+	[](const std::unique_ptr<Range>& r, std::uintptr_t value) {
 		return r->begin < value;
 	});
 

--- a/src/ranges.cpp
+++ b/src/ranges.cpp
@@ -48,25 +48,6 @@ bool Add(std::unique_ptr<Range> range) {
     return true;
 }
 
-bool IsIn(std::uintptr_t value) {
-	std::shared_lock lock(g_mutex);
-
-	auto it = std::upper_bound(
-	g_ranges.begin(),
-	g_ranges.end(),
-	value,
-	[](uint32_t v, const std::unique_ptr<Range>& r) {
-		return v < r->begin;
-	});
-
-	if (it == g_ranges.begin()) {
-		return false;
-	}
-
-	--it;
-	return value <= (*it)->end;
-}
-
 std::uintptr_t Lookup(std::uintptr_t start, std::size_t size, const std::string& bytes) {
 	// Parse the bytes sequence
 	std::vector<std::uint16_t> sequence;


### PR DESCRIPTION
A bunch of fixes that surfaced while wiring KHook into SourceMod on Linux x64.
Improved address handling, a couple of use-after-frees in hook logic, and JIT page protection. None of it is SourceMod-specific.

Each fix is its own commit.

The safetyhook submodule needs a bump after https://github.com/alliedmodders/safetyhook/pull/11 lands.