### PR TITLE
Fix std::max build break under function-like min/max macros

### DIFF
--- a/include/khook.hpp
+++ b/include/khook.hpp
@@ -9,6 +9,7 @@
 */
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <type_traits>
 #include <unordered_set>
@@ -95,10 +96,10 @@ protected:
 #else
 		std::uint32_t return_size = 0;
 		if constexpr(!std::is_void_v<RETURN>) {
-			return_size = std::max(sizeof(void*), sizeof(RETURN));
+			return_size = (std::max)(sizeof(void*), sizeof(RETURN));
 		}
 
-		return return_size + (std::max(sizeof(void*), sizeof(ARGS)) + ... + 0);
+		return return_size + ((std::max)(sizeof(void*), sizeof(ARGS)) + ... + 0);
 #endif
 	}
 protected:


### PR DESCRIPTION
Function-like min/max macros (e.g. `<windows.h>`) currently expand these, leading to errors when building. Also include `<algorithm>` directly instead of relying on another include.

https://stackoverflow.com/a/29742671